### PR TITLE
Return 404 if we cannot route a path

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -79,6 +79,9 @@ sub vcl_recv {
         set req.url = regsub(req.url, "^\/__[\w-]*\/(.*)$", "/\1");
         set req.http.X-VarnishPassThrough = "true";
     }
+    else {
+         return(synth(404, "Path not found"));
+    }
 
     return (pipe);
 }


### PR DESCRIPTION
- tested with paths
  - empty path
  - `/`
  - `/random-path`
  - `/__service-which-doesnt-exist`
  - `/multiple/path/elements/`
- returns 

```
HTTP/1.1 404 Not Found
Date: Wed, 10 Jan 2018 11:55:58 GMT
X-Request-Id: tid_yzcwflhxlg
X-Varnish: 819572
Retry-After: 5
Server: Varnish
Content-Type: text/html;charset=utf-8
Vary: X-Policy
Content-Length: 265
X-Varnish: 67091519
Age: 0
Via: 1.1 varnish-v4
X-Cache: MISS
Connection: keep-alive

<!DOCTYPE html>
<html>
  <head>
    <title>404 Path not found</title>
  </head>
  <body>
    <h1>Error 404 Path not found</h1>
    <p>Path not found</p>
    <h3>Guru Meditation:</h3>
    <p>XID: 819572</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>
```