### PR TITLE
Add advanced content search endpoint

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -26,6 +26,10 @@ sub vcl_recv {
     elif (req.url ~ "^\/content\/feed\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*$") {
         set req.backend_hint = dynBackend.backend("ccf-content-rss");
     }
+    elif(req.url ~ "^\/content\/advanced-search.*$") {
+        set req.url = "/search";
+        set req.backend_hint = dynBackend.backend("combined-content-search");
+    }
     elif (req.url ~ "^\/content\/.*$") {
         set req.backend_hint = dynBackend.backend("content-public-read");
     }


### PR DESCRIPTION
# Description

## What

Add `advanced-search` endpoint. It will be behind `api-policy component` and theoretically we would be able to use its functionality for manipulating the response. For example the `combined-content-search` returns `body-xml` which could be manipulated through `api-policy-component`. However to do so we should small make updates in the `api-policy-component` and change the output of the `combined-content-search` (`body_xml` -> `bodyXML`).

## Why

https://financialtimes.atlassian.net/browse/UPPSF-1841

## Anything, in particular, you'd like to highlight to reviewers

_Opening it as draft PR so we can discuss on whether this varnish is right place and whether we want this endpoint._  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
